### PR TITLE
Update to hybsearch/docker-base v1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/hybsearch/docker-base:v1.1
+FROM docker.io/hybsearch/docker-base:v1.2
 
 ADD . /jml
 WORKDIR /jml/src


### PR DESCRIPTION
This should slim any dependency installation down and make this image overall smaller.